### PR TITLE
chore(deps): downgrade @sveltejs/vite-plugin-svelte and @directus/sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@sveltejs/adapter-auto": "^6.0.1",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.27.0",
-		"@sveltejs/vite-plugin-svelte": "^6.1.0",
+		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"@tailwindcss/postcss": "^4.1.11",
 		"bits-ui": "^2.9.1",
 		"clsx": "^2.1.1",
@@ -37,7 +37,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@directus/sdk": "^20.0.1",
+		"@directus/sdk": "^17.0.0",
 		"embla-carousel-autoplay": "^8.6.0",
 		"iconify-icon": "^3.0.0",
 		"mode-watcher": "^1.1.0"


### PR DESCRIPTION
Downgrade @sveltejs/vite-plugin-svelte from 6.1.0 to 5.0.0 and @directus/sdk
from 20.0.1 to 17.0.0 to maintain compatibility with existing project
setup and avoid potential breaking changes introduced in newer versions.