### PR TITLE
chore: specify minimum Node.js version in package configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
 				"tw-animate-css": "^1.3.6",
 				"typescript": "^5.9.2",
 				"vite": "^7.0.6"
+			},
+			"engines": {
+				"node": ">=22.12.0"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "portfolio",
 	"version": "0.0.1",
 	"private": true,
+	"engines": {
+		"node": ">=22.12.0"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",


### PR DESCRIPTION
Add an engines field to package.json and package-lock.json to require
Node.js version 22.12.0 or higher. This ensures compatibility with
modern features and prevents issues on unsupported Node.js versions.