### PR TITLE
chore(deps): downgrade vite and svelte plugin versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@sveltejs/adapter-auto": "^6.0.1",
 				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.27.0",
-				"@sveltejs/vite-plugin-svelte": "^6.1.0",
+				"@sveltejs/vite-plugin-svelte": "^5.0.0",
 				"@tailwindcss/postcss": "^4.1.11",
 				"bits-ui": "^2.9.1",
 				"clsx": "^2.1.1",
@@ -35,10 +35,7 @@
 				"tailwindcss": "^4.1.11",
 				"tw-animate-css": "^1.3.6",
 				"typescript": "^5.9.2",
-				"vite": "^7.0.6"
-			},
-			"engines": {
-				"node": ">=22.12.0"
+				"vite": "^6.0.0"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -247,39 +244,43 @@
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "6.1.0",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+			"integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0-next.1",
+				"@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
 				"debug": "^4.4.1",
 				"deepmerge": "^4.3.1",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.17",
-				"vitefu": "^1.1.1"
+				"vitefu": "^1.0.6"
 			},
 			"engines": {
-				"node": "^20.19 || ^22.12 || >=24"
+				"node": "^18.0.0 || ^20.0.0 || >=22"
 			},
 			"peerDependencies": {
 				"svelte": "^5.0.0",
-				"vite": "^6.3.0 || ^7.0.0"
+				"vite": "^6.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-			"version": "5.0.0",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+			"integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"debug": "^4.4.1"
+				"debug": "^4.3.7"
 			},
 			"engines": {
-				"node": "^20.19 || ^22.12 || >=24"
+				"node": "^18.0.0 || ^20.0.0 || >=22"
 			},
 			"peerDependencies": {
-				"@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
+				"@sveltejs/vite-plugin-svelte": "^5.0.0",
 				"svelte": "^5.0.0",
-				"vite": "^6.3.0 || ^7.0.0"
+				"vite": "^6.0.0"
 			}
 		},
 		"node_modules/@swc/helpers": {
@@ -455,6 +456,8 @@
 		},
 		"node_modules/debug": {
 			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -814,6 +817,8 @@
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1270,22 +1275,24 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.0.6",
+			"version": "6.3.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",
-				"fdir": "^6.4.6",
-				"picomatch": "^4.0.3",
-				"postcss": "^8.5.6",
-				"rollup": "^4.40.0",
-				"tinyglobby": "^0.2.14"
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2",
+				"postcss": "^8.5.3",
+				"rollup": "^4.34.9",
+				"tinyglobby": "^0.2.13"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^20.19.0 || >=22.12.0"
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/vitejs/vite?sponsor=1"
@@ -1294,14 +1301,14 @@
 				"fsevents": "~2.3.3"
 			},
 			"peerDependencies": {
-				"@types/node": "^20.19.0 || >=22.12.0",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
 				"jiti": ">=1.21.0",
-				"less": "^4.0.0",
+				"less": "*",
 				"lightningcss": "^1.21.0",
-				"sass": "^1.70.0",
-				"sass-embedded": "^1.70.0",
-				"stylus": ">=0.54.8",
-				"sugarss": "^5.0.0",
+				"sass": "*",
+				"sass-embedded": "*",
+				"stylus": "*",
+				"sugarss": "*",
 				"terser": "^5.16.0",
 				"tsx": "^4.8.1",
 				"yaml": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
 	"name": "portfolio",
 	"version": "0.0.1",
 	"private": true,
-	"engines": {
-		"node": ">=22.12.0"
-	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -20,7 +17,7 @@
 		"@sveltejs/adapter-auto": "^6.0.1",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.27.0",
-		"@sveltejs/vite-plugin-svelte": "^6.1.0",
+		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"@tailwindcss/postcss": "^4.1.11",
 		"bits-ui": "^2.9.1",
 		"clsx": "^2.1.1",
@@ -36,7 +33,7 @@
 		"tailwindcss": "^4.1.11",
 		"tw-animate-css": "^1.3.6",
 		"typescript": "^5.9.2",
-		"vite": "^7.0.6"
+		"vite": "^6.0.0"
 	},
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
Revert @sveltejs/vite-plugin-svelte from 6.x to 5.x and vite from 7.x to 6.x.
Remove node engine requirement from package.json to increase compatibility.
Update related dependencies to match downgraded versions.

These changes address compatibility issues with the current environment
and ensure stable builds by using tested versions of core tooling.