### PR TITLE
chore(deps): bump SvelteKit and related libs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -945,9 +945,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.49.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.2.tgz",
-			"integrity": "sha512-Vp3zX/qlwerQmHMP6x0Ry1oY7eKKRcOWGc2P59srOp4zcqyn+etJyQpELgOi4+ZSUgteX8Y387NuwruLgGXLUQ==",
+			"version": "2.49.5",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.5.tgz",
+			"integrity": "sha512-dCYqelr2RVnWUuxc+Dk/dB/SjV/8JBndp1UovCyCZdIQezd8TRwFLNZctYkzgHxRJtaNvseCSRsuuHPeUgIN/A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -957,7 +957,7 @@
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.3.2",
+				"devalue": "^5.6.2",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -976,10 +976,14 @@
 				"@opentelemetry/api": "^1.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
+				"typescript": "^5.3.3",
 				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
 			},
 			"peerDependenciesMeta": {
 				"@opentelemetry/api": {
+					"optional": true
+				},
+				"typescript": {
 					"optional": true
 				}
 			}
@@ -1416,9 +1420,9 @@
 			}
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1464,9 +1468,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.1.tgz",
-			"integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
+			"integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
 		"embla-carousel-autoplay": "^8.6.0",
 		"iconify-icon": "^3.0.0",
 		"mode-watcher": "^1.1.0"
+	},
+	"overrides": {
+		"cookie": "^0.7.0"
 	}
 }


### PR DESCRIPTION
Update several dev dependencies to resolve compatibilty and security
issues and ensure newer peer ranges.

- Upgrade @sveltejs/kit from 2.49.2 to 2.49.5 to pick up fixes and
  updated dependency metadata.
- Bump devalue to 5.6.2 to include the latest patch fixes.
- Bump cookie to 0.7.2 and add an overrides entry for cookie ^0.7.0 to
  force the newer minor across the dependency tree.
- Add TypeScript as an optional peer in @sveltejs/kit metadata and pin a
  compatible range (^5.3.3) in the resolved entry to avoid peer warning.

These changes keep the project on supported dependency versions and
reduce peer/compatibility warnings during install.