### PR TITLE
chore(deps): bump tar to 7.5.7 in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2475,9 +2475,9 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-			"integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+			"version": "7.5.7",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+			"integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {


### PR DESCRIPTION
Update package-lock.json to reference tar v7.5.7 (previously 7.5.6).
This updates the resolved tar artifact and integrity hash to the
latest patch release. The change keeps dev dependency metadata in
sync with the installed package and ensures the lockfile reflects
the newer tar version for reproducible installs.